### PR TITLE
Remove is_palindrome function stub and associated file because  modul…

### DIFF
--- a/python/cci/2/6/is_palindrome.py
+++ b/python/cci/2/6/is_palindrome.py
@@ -1,5 +1,0 @@
-from ..node import Node
-
-
-def is_palindrome(head: Node) -> bool:
-    pass


### PR DESCRIPTION
…e folder names have to follow the naming convention of variable names and cannot be a number